### PR TITLE
Algorithm updates for typos in pseudocode and correction factor.

### DIFF
--- a/src/stcal/ramp_fitting/ols_cas22/_core.pyx
+++ b/src/stcal/ramp_fitting/ols_cas22/_core.pyx
@@ -128,6 +128,9 @@ cpdef inline float threshold(Thresh thresh, float slope):
     -------
         intercept - constant * log10(slope)
     """
+    # clip slope in 1, 1e4
+    slope = slope if slope > 1 else 1
+    slope = slope if slope < 1e4 else 1e4
     return thresh.intercept - thresh.constant * log10(slope)
 
 

--- a/src/stcal/ramp_fitting/ols_cas22/_fixed.pyx
+++ b/src/stcal/ramp_fitting/ols_cas22/_fixed.pyx
@@ -67,10 +67,10 @@ cdef class FixedValues:
         fit.
             single of slope variance term:
                 var_slope_coeffs[Diff.single, :] = (tau[i] + tau[i+1]
-                                                    - min(t_bar[i], t_bar[i+1]))
+                                                    - 2 * min(t_bar[i], t_bar[i+1]))
             double of slope variance term:
                 var_slope_coeffs[Diff.double, :] = (tau[i] + tau[i+2]
-                                                    - min(t_bar[i], t_bar[i+2]))
+                                                    - 2 * min(t_bar[i], t_bar[i+2]))
 
     Notes
     -----
@@ -172,8 +172,8 @@ cdef class FixedValues:
 
         cdef np.ndarray[float, ndim=2] var_slope_vals = np.zeros((2, self.data.t_bar.size() - 1), dtype=np.float32)
 
-        var_slope_vals[Diff.single, :] = (np.add(tau[1:], tau[:end - 1]) - np.minimum(t_bar[1:], t_bar[:end - 1]))
-        var_slope_vals[Diff.double, :end - 2] = (np.add(tau[2:], tau[:end - 2]) - np.minimum(t_bar[2:], t_bar[:end - 2]))
+        var_slope_vals[Diff.single, :] = (np.add(tau[1:], tau[:end - 1]) - 2 * np.minimum(t_bar[1:], t_bar[:end - 1]))
+        var_slope_vals[Diff.double, :end - 2] = (np.add(tau[2:], tau[:end - 2]) - 2 * np.minimum(t_bar[2:], t_bar[:end - 2]))
         var_slope_vals[Diff.double, end - 2] = np.nan  # last double difference is undefined
 
         return var_slope_vals

--- a/src/stcal/ramp_fitting/ols_cas22/_pixel.pyx
+++ b/src/stcal/ramp_fitting/ols_cas22/_pixel.pyx
@@ -274,10 +274,11 @@ cdef class Pixel:
         cdef float delta = (self.local_slopes[diff, index] - slope)
         cdef float var = ((self.var_read_noise[diff, index] +
                            slope * self.fixed.var_slope_coeffs[diff, index])
-                          / self.fixed.t_bar_diff_sqrs[diff, index]) 
+                          / self.fixed.t_bar_diff_sqrs[diff, index])
         cdef float correct = self.correction(ramp, slope)
+        var += correct
 
-        return (delta / sqrt(var)) + correct
+        return (delta / sqrt(var))
 
 
     @cython.boundscheck(False)
@@ -554,6 +555,6 @@ cpdef inline Pixel make_pixel(FixedValues fixed, float read_noise, float [:] res
     # Pre-compute values for jump detection shared by all pixels for this pixel
     if fixed.use_jump:
         pixel.local_slopes = pixel.local_slope_vals()
-        pixel.var_read_noise = read_noise * np.array(fixed.read_recip_coeffs)
+        pixel.var_read_noise = read_noise**2 * np.array(fixed.read_recip_coeffs)
 
     return pixel

--- a/src/stcal/ramp_fitting/ols_cas22_fit.py
+++ b/src/stcal/ramp_fitting/ols_cas22_fit.py
@@ -125,7 +125,7 @@ def fit_ramps_casertano(
         read_noise.reshape(-1),
         read_time,
         read_pattern,
-        use_jump, include_diagnostic=True,
+        use_jump,
         **kwargs)
 
     parameters = output.parameters.reshape(orig_shape[1:] + (2,))

--- a/src/stcal/ramp_fitting/ols_cas22_fit.py
+++ b/src/stcal/ramp_fitting/ols_cas22_fit.py
@@ -125,7 +125,7 @@ def fit_ramps_casertano(
         read_noise.reshape(-1),
         read_time,
         read_pattern,
-        use_jump,
+        use_jump, include_diagnostic=True,
         **kwargs)
 
     parameters = output.parameters.reshape(orig_shape[1:] + (2,))


### PR DESCRIPTION
I tried to hunt down the differences between Sanjib's jump detection results and what your code was getting in stcal.

I found two typos in the pseudocode that I have fixed here (read noise should have been squared in the variance and in the jump detection code, and there was a missing factor of two in the pseudocode and in the code).  I also added a clamping of the slope before sending to the thresholding following Sanjib's advice, though this didn't change the results on this data set.

Finally, the correction factor to the variance was being applied in the wrong place; I've moved it to the right place.

In the end the agreement with Sanjib's test data set is much improved; we disagree only on 550/750,000 jumps in the test data set I looked at.  Sanjib thinks he might be able to improve that more; he may have been playing a bit with the variance calculation for the results he sent us.  But we're pretty darn close.